### PR TITLE
Changed redirect link from youtube-channel to the youtube workshops playlist

### DIFF
--- a/docs/2021-2022-summer/index.md
+++ b/docs/2021-2022-summer/index.md
@@ -18,4 +18,4 @@ Foodbank is mainly with frontend with React + NextJS + TypeScript + TailwindCSS 
 WAIS is a full-stack application with Vue and Django. It uses Docker containerisation for both development (and production in the future).
 
 ## Workshop Recordings
-The workshop recordings will be held on our [youtube channel](https://www.youtube.com/channel/UCp47I0qUXeGgSK0AtFJSkbQ).
+The workshop recordings will be held on our [youtube channel](https://www.youtube.com/playlist?list=PL4p180vnG7j5Q67VXMxvQTE45bR3IDzIr).


### PR DESCRIPTION
## Change Summary
* Just updated the YouTube link to redirect user to the summer projects 2021 playlist rather than the channel. This way they don't need to manually search for the 2021 workshops.
