### PR TITLE
Fix dark theme colours in ERDs 

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -125,8 +125,8 @@
   --md-primary-fg-color--dark: #000;
   --md-primary-bg-color: #fff;
   --md-primary-bg-color--light: #fff;
-  --md-accent-fg-color: #8ff;
-  --md-accent-fg-color--transparent: #8ff;
+  --md-accent-fg-color: #4db4d0;
+  --md-accent-fg-color--transparent: #4db4d0;
   --md-accent-bg-color: #000;
   --md-accent-bg-color--light: #000;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:mermaid2.fence_mermaid_custom
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid_custom
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 extra:
   social:


### PR DESCRIPTION
## Change Summary
- Changed one of the many css variables in the dark theme so that there is suitable colour contrast in the ERDs (see the 2024 django workshop).
 Before:
![image](https://github.com/user-attachments/assets/3123a8a4-91d8-4f6a-b66c-e0d8413c5263)

  After:
![image](https://github.com/user-attachments/assets/047ebb1a-4a55-4b1d-a3df-e09aade5f779)


### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**